### PR TITLE
chore: optional tls cert

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export interface TapdClientOptions {
    * @cert tapd's TLS certificate in HEX format.
    */
 
-  cert: string;
+  cert?: string;
 }
 
 /**

--- a/src/proto.ts
+++ b/src/proto.ts
@@ -21,14 +21,25 @@ export const loadProto = <T>(
     }
   );
 
-  const channelCredentials = grpc.credentials.createSsl(
-    Buffer.from(options.cert, 'hex')
-  );
+  let credentials;
 
-  const credentials = grpc.credentials.combineChannelCredentials(
-    channelCredentials,
-    callCredentials
-  );
+  if (options.cert) {
+    const channelCredentials = grpc.credentials.createSsl(
+      Buffer.from(options.cert, 'hex')
+    );
+  
+    credentials = grpc.credentials.combineChannelCredentials(
+      channelCredentials,
+      callCredentials
+    );
+  } else {
+    const channelCredentials = grpc.credentials.createSsl();
+
+    credentials = grpc.credentials.combineChannelCredentials(
+      channelCredentials,
+      callCredentials
+    );
+  }
 
   const params: grpc.ClientOptions = {
     'grpc.max_receive_message_length': -1,


### PR DESCRIPTION
Some setups don't require a TLS certificate, like Voltage's. 

The `lightning` library also has the `cert` field optional, so I went with the same approach